### PR TITLE
Webpack 模块小功能改进

### DIFF
--- a/packages/module-webpack/src/index.ts
+++ b/packages/module-webpack/src/index.ts
@@ -19,6 +19,7 @@ export default class ModuleWebpack extends Module.Callback<ModuleWebpack.Config>
   public config?: Webpack.Configuration | Webpack.Configuration[];
   public firstConfig?: Webpack.Configuration;
   public alreadyRun = false;
+  public alreadyOpen = false;
 
   public async init() {
     const { logger } = this.$utils;
@@ -331,6 +332,10 @@ export default class ModuleWebpack extends Module.Callback<ModuleWebpack.Config>
       }
       const donePromise = new Promise(resolve => {
         this.compiler!.plugin('done', () => {
+          if (!this.alreadyOpen) {
+            reportReadiness(options, (this.server as any).listeningApp, suffix);
+            this.alreadyOpen = true;
+          }
           done();
           resolve();
         });
@@ -384,7 +389,6 @@ export default class ModuleWebpack extends Module.Callback<ModuleWebpack.Config>
             if (fsError) {
               throw fsError;
             }
-            reportReadiness(options, (this.server as any).listeningApp, suffix);
           });
         });
       } else {
@@ -395,7 +399,6 @@ export default class ModuleWebpack extends Module.Callback<ModuleWebpack.Config>
           if (options.bonjour) {
             broadcastZeroconf(options);
           }
-          reportReadiness(options, (this.server as any).listeningApp, suffix);
         });
       }
       await donePromise;

--- a/packages/module-webpack/src/index.ts
+++ b/packages/module-webpack/src/index.ts
@@ -218,7 +218,7 @@ export default class ModuleWebpack extends Module.Callback<ModuleWebpack.Config>
         console.warn(`[Network] Using family ${family}`);
       }
       const protocol = options.https ? 'https:' : 'http:';
-      const localhostURI = `${protocol}//localhost:${port}${suffix}`;
+      const localhostURI = `${protocol}//127.0.0.1:${port}${suffix}`;
       const useColor = isSupportColor;
       const contentBase = Array.isArray(options.contentBase) ? options.contentBase.join(', ') : options.contentBase;
       if (!options.quiet) {


### PR DESCRIPTION
1. 调整打开浏览器标签时机：调整为 **webpack** 编译结束
2. 默认打开 `http://127.0.0.1:8080`

调整打开浏览器标签时机为编译结束，是为了让用户不再感觉页面渲染“慢”。
将部分等待时间放到“命令行”上。
